### PR TITLE
Updated continue-on-error as an input

### DIFF
--- a/python-lint/action.yml
+++ b/python-lint/action.yml
@@ -13,7 +13,7 @@ inputs:
   continue-on-error:
     description: "Continue on error"
     required: false
-    default: "false"
+    default: false
 
 runs:
   using: "composite"

--- a/python-lint/action.yml
+++ b/python-lint/action.yml
@@ -10,6 +10,11 @@ inputs:
     description: "The version of Poetry to use"
     required: true
 
+  continue-on-error:
+    description: "Continue on error"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   
@@ -43,20 +48,20 @@ runs:
 
     - name: Run Black
       run: poetry run black --check .
-      continue-on-error: true          #Added so to provide lineance while lint 
+      continue-on-error: ${{ inputs.continue-on-error }}         #Added so to provide lineance while lint 
       shell: bash
 
     - name: Run Flake8
       run: poetry run flake8 .
-      continue-on-error: true          #Added so to provide lineance while lint
+      continue-on-error: ${{ inputs.continue-on-error }}           #Added so to provide lineance while lint
       shell: bash
 
     - name: Run isort
       run: poetry run isort --check .
-      continue-on-error: true           #Added so to provide lineance while lint
+      continue-on-error: ${{ inputs.continue-on-error }}           #Added so to provide lineance while lint
       shell: bash
 
     - name: Run mypy
       run: poetry run mypy .
-      continue-on-error: true          #Added so to provide lineance while lint
+      continue-on-error: ${{ inputs.continue-on-error }}          #Added so to provide lineance while lint
       shell: bash

--- a/python-test/action.yml
+++ b/python-test/action.yml
@@ -8,6 +8,10 @@ inputs:
   poetry-version:
     description: "The version of Poetry to install"
     required: true
+  continue-on-error:
+    description: "Continue on error"
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -46,5 +50,5 @@ runs:
 
     - name: Run Test
       run: poetry run pytest
-      continue-on-error: true
+      continue-on-error: ${{ inputs.continue-on-error }}
       shell: bash


### PR DESCRIPTION
Made `continue-on-error` as an input for python-lint and python-test