### PR TITLE
feat: optional Bun support for frontend Actions

### DIFF
--- a/build-FE/action.yml
+++ b/build-FE/action.yml
@@ -1,18 +1,31 @@
-name: Node.js Test
-description: Test a Node.js application (supports yarn or bun).
-author: Prakhar
+name: Build Docker Image
+
+description: Build a Docker image for a frontend application (supports yarn or bun).
+
 inputs:
+  image_name:
+    description: 'The name and tag of the Docker image (e.g., my-image:latest).'
+    required: true
+  dockerfile:
+    description: 'Path to the Dockerfile.'
+    required: true
+    default: 'Dockerfile'
+  context:
+    description: 'Build context path.'
+    required: true
+    default: '.'
   node-version:
     description: 'Node.js version to use'
     required: true
     default: '20'
   registry-url:
-    description: 'Registry URL for npm packages'
+    description: 'Registry URL for NPM packages'
     required: true
     default: 'https://npm.pkg.github.com'
   node-auth-token:
     description: 'NPM Auth Token for accessing private packages'
     required: true
+    default: ''
   package-manager:
     description: 'Package manager to use: yarn or bun'
     required: false
@@ -62,11 +75,10 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       run: yarn install
 
-    - name: Run Test (yarn)
+    - name: Build the application (yarn)
       if: ${{ inputs.package-manager == 'yarn' }}
       shell: bash
-      run: yarn test
-      continue-on-error: true
+      run: yarn build
 
     - name: Install dependencies (bun)
       if: ${{ inputs.package-manager == 'bun' }}
@@ -75,10 +87,22 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       run: bun install --frozen-lockfile
 
-    - name: Run Test (bun)
+    - name: Build the application (bun)
       if: ${{ inputs.package-manager == 'bun' }}
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
-      run: bun run test
-      continue-on-error: true
+      run: bun run build
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      id: build
+      shell: bash
+      run: |
+        docker build -t ${{ inputs.image_name }} -f ${{ inputs.dockerfile }} ${{ inputs.context }}
+
+    - name: List Docker Images
+      shell: bash
+      run: docker images

--- a/build-and-scan-FE/action.yml
+++ b/build-and-scan-FE/action.yml
@@ -26,29 +26,76 @@ inputs:
     description: 'NPM Auth Token for accessing private packages'
     required: true
     default: ''  # Default can be blank
+  package-manager:
+    description: 'Package manager to use: yarn or bun'
+    required: false
+    default: 'yarn'
+  bun-version:
+    description: 'Bun version when package-manager is bun'
+    required: false
+    default: '1.3.14'
 
 runs:
   using: 'composite'
   steps:
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
+    - name: Write .npmrc for GitHub Packages
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: |
+        echo "@urbint:registry=https://npm.pkg.github.com/" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        echo "always-auth=true" >> .npmrc
+        echo "NPM_CONFIG_USERCONFIG=" >> "$GITHUB_ENV"
+
+    - name: Set up Node.js (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        registry-url: ${{ inputs.registry-url }}  # Pass the registry URL
+        registry-url: ${{ inputs.registry-url }}
         always-auth: true
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
-    - name: Install dependencies
-      run: |
-        yarn install
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}  # Use the provided auth token
-      shell: bash  # Specify the shell for this step
 
-    - name: Build the application
-      run: |
-        yarn build  # Add the build step
-      shell: bash  # Specify the shell for this step
+    - name: Set up Node.js (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Set up Bun
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: yarn install
+
+    - name: Build the application (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      run: yarn build
+
+    - name: Install dependencies (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun install --frozen-lockfile
+
+    - name: Build the application (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun run build
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/docker-push-frontend-ecr/action.yml
+++ b/docker-push-frontend-ecr/action.yml
@@ -34,6 +34,14 @@ inputs:
   target:
     description: 'Optional build target for the Docker image'
     required: false
+  package-manager:
+    description: 'Package manager to use: yarn or bun'
+    required: false
+    default: 'yarn'
+  bun-version:
+    description: 'Bun version when package-manager is bun'
+    required: false
+    default: '1.3.14'
 
 runs:
   using: 'composite'
@@ -59,23 +67,61 @@ runs:
             --password-stdin ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_region }}.amazonaws.com
       shell: bash
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
+    - name: Write .npmrc for GitHub Packages
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: |
+        echo "@urbint:registry=https://npm.pkg.github.com/" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        echo "always-auth=true" >> .npmrc
+        echo "NPM_CONFIG_USERCONFIG=" >> "$GITHUB_ENV"
+
+    - name: Set up Node.js (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
-    - name: Install dependencies
-      run: |
-        yarn install
+    - name: Set up Node.js (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Set up Bun
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
-      shell: bash
+      run: yarn install
 
-    - name: Build the application
-      run: |
-        yarn build
+    - name: Build the application (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
       shell: bash
+      run: yarn build
+
+    - name: Install dependencies (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun install --frozen-lockfile
+
+    - name: Build the application (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun run build
 
     - name: Build and Push Docker Image (No Target)
       if: ${{ !inputs.target }}

--- a/docker-push-frontend-gcr-ecr/action.yml
+++ b/docker-push-frontend-gcr-ecr/action.yml
@@ -41,11 +41,19 @@ inputs:
   node-auth-token:
     description: 'NPM Auth Token for accessing private packages'
     required: true
+  package-manager:
+    description: 'Package manager to use: yarn or bun'
+    required: false
+    default: 'yarn'
+  bun-version:
+    description: 'Bun version when package-manager is bun'
+    required: false
+    default: '1.3.14'
 
 runs:
   using: 'composite'
   steps:
-    # Prefer project .npmrc over setup-node registry-url (Yarn 1 + lockfile URLs).
+    # Prefer project .npmrc over setup-node registry-url (lockfile tarball URLs).
     - name: Write .npmrc for GitHub Packages
       shell: bash
       env:
@@ -61,15 +69,37 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Install dependencies
+    - name: Set up Bun
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       run: yarn install --frozen-lockfile
 
-    - name: Build the application
+    - name: Build the application (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
       shell: bash
       run: yarn build
+
+    - name: Install dependencies (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun install --frozen-lockfile
+
+    - name: Build the application (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun run build
 
     - name: Authenticate to Google Cloud
       id: auth

--- a/docker-push-frontend/action.yml
+++ b/docker-push-frontend/action.yml
@@ -1,5 +1,5 @@
 name: 'Docker Push to GCR'
-description: 'Builds and pushes a Docker image to Google Container Registry'
+description: 'Builds and pushes a Docker image to Google Container Registry (supports yarn or bun)'
 inputs:
   tag:
     description: 'Tag for the Docker image (e.g., latest or commit SHA)'
@@ -14,20 +14,26 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: true
-    default: '20' 
+    default: '20'
   registry-url:
     description: 'Registry URL for NPM packages'
     required: true
   node-auth-token:
     description: 'NPM Auth Token for accessing private packages'
     required: true
-    default: '' 
-  
+    default: ''
   image_name:
     description: 'Name of the Docker image (default: my-frontend-image)'
     required: true
     default: 'my-frontend-image'
-
+  package-manager:
+    description: 'Package manager to use: yarn or bun'
+    required: false
+    default: 'yarn'
+  bun-version:
+    description: 'Bun version when package-manager is bun'
+    required: false
+    default: '1.3.14'
 
 runs:
   using: 'composite'
@@ -40,7 +46,7 @@ runs:
       uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ inputs.gcr_sa_key }}
-        token_format: "access_token"  
+        token_format: "access_token"
 
     - name: Log into Google Container Registry
       uses: docker/login-action@v2
@@ -49,28 +55,66 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
+    - name: Write .npmrc for GitHub Packages
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: |
+        echo "@urbint:registry=https://npm.pkg.github.com/" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        echo "always-auth=true" >> .npmrc
+        echo "NPM_CONFIG_USERCONFIG=" >> "$GITHUB_ENV"
+
+    - name: Set up Node.js (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
-    - name: Install dependencies
-      run: |
-        yarn install
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}  
-      shell: bash  
+    - name: Set up Node.js (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
 
-    - name: Build the application
-      run: |
-        yarn build  # Add the build step
-      shell: bash  
+    - name: Set up Bun
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: yarn install
+
+    - name: Build the application (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      run: yarn build
+
+    - name: Install dependencies (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun install --frozen-lockfile
+
+    - name: Build the application (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun run build
 
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v5
       with:
         context: .
-        file: ${{ inputs.dockerfile }}  
+        file: ${{ inputs.dockerfile }}
         push: true
-        tags: gcr.io/urbint-1259/${{ inputs.image_name }}:${{ inputs.tag }} 
+        tags: gcr.io/urbint-1259/${{ inputs.image_name }}:${{ inputs.tag }}

--- a/typescript-lint/action.yml
+++ b/typescript-lint/action.yml
@@ -1,38 +1,82 @@
 name: Node.js Lint
-description: Lint a Node.js application.
+description: Lint a Node.js application (supports yarn or bun).
 author: Prakhar
-runs:
-  using: 'composite'
-  steps:
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ inputs.node-version }}
-        registry-url: ${{ inputs.registry-url }}  
-
-    - name: Install dependencies
-      run: |
-        yarn install
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
-      shell: bash
-
-    - name: Run Lint
-      run: |
-        yarn lint
-      shell: bash
-
 inputs:
   node-version:
     description: 'Node.js version to use'
     required: true
     default: '20'
-  
   registry-url:
     description: 'Registry URL for npm packages'
     required: true
-    default: 'https://npm.pkg.github.com'  
-
+    default: 'https://npm.pkg.github.com'
   node-auth-token:
     description: 'NPM Auth Token for accessing private packages'
-    required: true  
+    required: true
+  package-manager:
+    description: 'Package manager to use: yarn or bun'
+    required: false
+    default: 'yarn'
+  bun-version:
+    description: 'Bun version when package-manager is bun'
+    required: false
+    default: '1.3.14'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Write .npmrc for GitHub Packages
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: |
+        echo "@urbint:registry=https://npm.pkg.github.com/" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        echo "always-auth=true" >> .npmrc
+        echo "NPM_CONFIG_USERCONFIG=" >> "$GITHUB_ENV"
+
+    - name: Set up Node.js (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Set up Node.js (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Set up Bun
+      if: ${{ inputs.package-manager == 'bun' }}
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: yarn install
+
+    - name: Run Lint (yarn)
+      if: ${{ inputs.package-manager == 'yarn' }}
+      shell: bash
+      run: yarn lint
+
+    - name: Install dependencies (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun install --frozen-lockfile
+
+    - name: Run Lint (bun)
+      if: ${{ inputs.package-manager == 'bun' }}
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: bun run lint


### PR DESCRIPTION
## Summary
- Add optional `package-manager` input (`yarn` default, or `bun`) to FE actions that currently hardcode `yarn install` / `yarn build`
- Actions updated: `build-FE` (added to main), `build-and-scan-FE`, `docker-push-frontend`, `docker-push-frontend-ecr`, `docker-push-frontend-gcr-ecr`, `typescript-lint`, `typescript-test`
- Existing Yarn callers are unchanged (default `yarn`)

## Why
`worker-safety-client` migrated to Bun (`packageManager: bun@1.3.14`). Shared actions still ran `yarn install`, which fails against Bun lockfiles.

## Usage
```yaml
uses: urbint/github-actions-library/build-FE@main
with:
  package-manager: bun
  bun-version: "1.3.14"
  node-version: "20.19.6"
  node-auth-token: ${{ github.token }}
```

## Test plan
- [ ] Existing yarn callers still work with no new inputs
- [ ] worker-safety-client can pass `package-manager: bun` for build / push / lint

Made with [Cursor](https://cursor.com)